### PR TITLE
Fix: ArticleSlideshow drag issue

### DIFF
--- a/src/blocks/ArticleSlideshow/ArticleSlideshow.js
+++ b/src/blocks/ArticleSlideshow/ArticleSlideshow.js
@@ -76,10 +76,16 @@ function ArticleSlideshow(props) {
 
   const { t } = useI18n()
 
-  const [emblaRef] = useEmblaCarousel({
+  const [emblaRef, embla] = useEmblaCarousel({
     align: 'start',
     containScroll: 'trimSnaps',
   })
+
+  React.useEffect(() => {
+    if (embla && embla.slideNodes().length !== items.length) {
+      embla.reInit()
+    }
+  }, [embla, items])
 
   return (
     <ArticleSlideshowRoot>


### PR DESCRIPTION
Fixes issue with the slideshow being unable to settle when dragging.

This issue happens because Embla inits before there are any slides to use.

Ref: https://github.com/davidcetinkaya/embla-carousel/issues/159#issuecomment-805024840