### PR TITLE
feat(Storybook): Add MUI breakpoints as viewport options

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -7,24 +7,25 @@ import { settings } from 'api/__mock__'
 import { CheckoutProvider, I18nProvider, SettingsProvider } from 'api'
 import { AppProvider } from 'containers/App/AppContext'
 import { createTheme } from 'components/styles'
-import MuiBreakpoints from 'components/styles/breakpoints'
+import breakpoints from 'components/styles/breakpoints'
 
-const breakpoints = {
-  ...MuiBreakpoints.values,
+const breakpointValues = {
+  ...breakpoints.values,
   xs: 375,
 }
 
-const viewports = Object.keys(breakpoints).reduce((acc, current) => {
-  acc[current] = {
-    name: current,
+const viewports = {}
+Object.entries(breakpointValues).forEach((key, value) => {
+  viewports[key] = {
+    name: key,
     styles: {
-      width: `${breakpoints[current]}px`,
+      width: `${value}px`,
       height: '960px',
     },
   }
 
   return acc
-}, {})
+})
 
 export const parameters = {
   layout: 'fullscreen',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -7,6 +7,7 @@ import { settings } from 'api/__mock__'
 import { CheckoutProvider, I18nProvider, SettingsProvider } from 'api'
 import { AppProvider } from 'containers/App/AppContext'
 import { createTheme } from 'components/styles'
+import breakpoints from 'components/styles/breakpoints'
 
 export const parameters = {
   layout: 'fullscreen',
@@ -15,6 +16,15 @@ export const parameters = {
       method: 'alphabetical',
       order: ['Common', 'Components', 'Containers', 'Blocks', 'Pages'],
     },
+  },
+  viewport: {
+    viewports: Object.keys(breakpoints.values).map((key, idx) => ({
+      name: key,
+      styles: {
+        height: '100%',
+        width: breakpoints.values[key],
+      },
+    })),
   },
 }
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -7,7 +7,24 @@ import { settings } from 'api/__mock__'
 import { CheckoutProvider, I18nProvider, SettingsProvider } from 'api'
 import { AppProvider } from 'containers/App/AppContext'
 import { createTheme } from 'components/styles'
-import breakpoints from 'components/styles/breakpoints'
+import MuiBreakpoints from 'components/styles/breakpoints'
+
+const breakpoints = {
+  ...MuiBreakpoints.values,
+  xs: 375,
+}
+
+const viewports = Object.keys(breakpoints).reduce((acc, current) => {
+  acc[current] = {
+    name: current,
+    styles: {
+      width: `${breakpoints[current]}px`,
+      height: '960px',
+    },
+  }
+
+  return acc
+}, {})
 
 export const parameters = {
   layout: 'fullscreen',
@@ -18,13 +35,7 @@ export const parameters = {
     },
   },
   viewport: {
-    viewports: Object.keys(breakpoints.values).map((key, idx) => ({
-      name: key,
-      styles: {
-        height: '100%',
-        width: breakpoints.values[key],
-      },
-    })),
+    viewports,
   },
 }
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -14,18 +14,17 @@ const breakpointValues = {
   xs: 375,
 }
 
-const viewports = {}
-Object.entries(breakpointValues).forEach((key, value) => {
+const viewports = Object.entries(breakpointValues).reduce((acc, [key, val]) => {
   viewports[key] = {
     name: key,
     styles: {
-      width: `${value}px`,
+      width: `${val}px`,
       height: '960px',
     },
   }
 
   return acc
-})
+}, {})
 
 export const parameters = {
   layout: 'fullscreen',


### PR DESCRIPTION
This PR adds MUI breakpoints as viewport options in Storybook.
Will use `375px` instead of `0px` for the `xs` breakpoint.



https://user-images.githubusercontent.com/6391986/157229375-ddeb0272-950e-4a2f-814a-026a561ed3fb.mp4


