### PR TITLE
Feature/emotion-component-reference

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -17,6 +17,8 @@ module.exports = {
     [
       '@emotion',
       {
+        // Allows an emotion component to be used as a CSS selector.
+        // https://github.com/mui/material-ui/issues/26366#issuecomment-942435579
         importMap: {
           '@mui/system': {
             styled: {

--- a/babel.config.js
+++ b/babel.config.js
@@ -14,6 +14,25 @@ module.exports = {
     ],
   ],
   plugins: [
+    [
+      '@emotion',
+      {
+        importMap: {
+          '@mui/system': {
+            styled: {
+              canonicalImport: ['@emotion/styled', 'default'],
+              styledBaseImport: ['@mui/system', 'styled'],
+            },
+          },
+          '@mui/material/styles': {
+            styled: {
+              canonicalImport: ['@emotion/styled', 'default'],
+              styledBaseImport: ['@mui/material/styles', 'styled'],
+            },
+          },
+        },
+      },
+    ],
     'babel-plugin-optimize-clsx',
     [
       'babel-plugin-i18n-tag-translate',

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@babel/core": "^7.14.6",
     "@babel/plugin-transform-react-constant-elements": "^7.10.1",
+    "@emotion/babel-plugin": "^11.7.2",
     "@next/bundle-analyzer": "^12.1.0",
     "@noaignite/eslint-config": "^0.2.0",
     "@storybook/addon-a11y": "^6.4.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1370,7 +1370,7 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz#9283c9ce5b289a3c4f61c12757469e59377f81f3"
   integrity sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==
 
-"@emotion/babel-plugin@^11.7.1":
+"@emotion/babel-plugin@^11.7.1", "@emotion/babel-plugin@^11.7.2":
   version "11.7.2"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz#fec75f38a6ab5b304b0601c74e2a5e77c95e5fa0"
   integrity sha512-6mGSCWi9UzXut/ZAN6lGFu33wGR3SJisNl3c0tvlmb8XChH1b2SUvxvnOh7hvLpqyRdHHU9AiazV3Cwbk5SXKQ==


### PR DESCRIPTION
Overview
---------
This PR enables emotion components to be targeted like regular CSS selectors using [@emotion/babel-plugin](https://emotion.sh/docs/@emotion/babel-plugin). Working for MUI v5 client-side & server-side application

```js

const Parent = styled.div`
  background: 'white'
`

const Button = styled.button`
  color: green;

 [`${Parent} &`] : {
  color: 'red'
 }
`
```